### PR TITLE
Update variables.go

### DIFF
--- a/proctl/variables.go
+++ b/proctl/variables.go
@@ -692,6 +692,9 @@ func (thread *ThreadContext) readString(addr uintptr) (string, error) {
 		return "", err
 	}
 	addr = uintptr(binary.LittleEndian.Uint64(val))
+	if addr == 0 {
+		return "", err
+	}
 
 	val, err = thread.readMemory(addr, strlen)
 	if err != nil {


### PR DESCRIPTION
Fixed the 'index out of range' runtime error by testing for a bogus address and returning an empty string out of ReadString.
